### PR TITLE
feat(events): remove event bubble before diagram goes healthy

### DIFF
--- a/src/views/Studio/Events.vue
+++ b/src/views/Studio/Events.vue
@@ -71,9 +71,11 @@ export default class Events extends Vue {
   private stopPublishCb: Function | null = null
 
   mounted () {
+    event.$on('publish', () => {
+      this.firedEvents = []
+    })
     event.$on('published', async (cb: Function) => {
       this.stopPublishCb = cb
-      this.firedEvents = []
       let i = 0
       this.interval = setInterval(() => {
         if (this.events.length === 0 || i === this.events.length) {

--- a/tests/unit/views/Studio/Events.spec.ts
+++ b/tests/unit/views/Studio/Events.spec.ts
@@ -79,6 +79,14 @@ describe('Events.vue', () => {
   })
 
   describe('event.$on(publish)', () => {
+    it('should reset the display event cards', () => {
+      vm.firedEvents = ['toto', 'tata']
+      event.$emit('publish')
+      expect(vm.firedEvents).toEqual([])
+    })
+  })
+
+  describe('event.$on(publish)', () => {
     it('should add 5 events as a stack', async () => {
       expect.assertions(1)
       const fakeCb = jest.fn()


### PR DESCRIPTION
## Acceptance

**Given** I have already published a story
**When** I click publish again
**Then** I see the events immediately clearing (rather than waiting for services to go healthy again)