### PR TITLE
feat(archi): remove k8s and story tiles + col displaying

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @storyscript/frontend 

--- a/src/views/Studio/Architecture.vue
+++ b/src/views/Studio/Architecture.vue
@@ -12,107 +12,63 @@
       Architecture
     </s-text>
     <perfect-scrollbar class="bg-gray-10 p-8 max-h-xs">
-      <perfect-scrollbar class="flex">
-        <div
-          v-for="(c, idx) in services"
-          :key="`card-${idx}`"
-          class="card flex items-center bg-white rounded-md w-1/2-gutter-1 mb-2 transition-all-faster"
-          :class="{
-            'mr-2': idx !== services.length - 1,
-            'bg-white': showServices !== idx || !blink,
-            'bg-green-20': showServices === idx && blink
-          }"
-        >
-          <div class="px-6 my-3 py-3 border-r border-gray-20">
-            <div class="w-6 h-6">
-              <img
-                :src="`/img/services/${c}.svg`"
-                :alt="`${c} logo`"
-              >
-            </div>
+      <div
+        v-for="(c, idx) in services"
+        :key="`card-${idx}`"
+        class="card flex items-center bg-white rounded-md w-full mb-2 transition-all-faster"
+        :class="{
+          'mr-2': idx !== services.length - 1,
+          'bg-white': showServices !== idx || !blink,
+          'bg-green-20': showServices === idx && blink
+        }"
+      >
+        <div class="px-6 my-3 py-3 border-r border-gray-20">
+          <div class="w-6 h-6">
+            <img
+              :src="`/img/services/${c}.svg`"
+              :alt="`${c} logo`"
+            >
           </div>
-          <div class="flex items-center justify-end w-full p-4">
+        </div>
+        <div class="flex items-center justify-end w-full p-4">
+          <div
+            v-show="showServices < idx"
+            class="flex items-center"
+          >
+            <s-text
+              p="5"
+              weight="bold"
+              color="text-yellow-60"
+            >
+              Staged
+            </s-text>
+            <s-icon
+              icon="error-warning-f"
+              color="text-yellow-60"
+              class="ml-3"
+              width="24"
+              height="24"
+            />
+          </div>
+          <transition name="zoom-in">
             <div
-              v-show="showServices < idx"
+              v-show="showServices >= idx"
               class="flex items-center"
             >
               <s-text
                 p="5"
                 weight="bold"
-                color="text-yellow-60"
+                color="text-green-70"
               >
-                Staged
+                Healthy
               </s-text>
               <s-icon
-                icon="error-warning-f"
-                color="text-yellow-60"
-                class="ml-3"
-                width="24"
-                height="24"
+                icon="check"
+                color="text-green-50"
+                class="bg-green-10 border border-green-30 rounded-full w-6 h-6 flex items-center justify-center ml-3"
               />
             </div>
-            <transition name="zoom-in">
-              <div
-                v-show="showServices >= idx"
-                class="flex items-center"
-              >
-                <s-text
-                  p="5"
-                  weight="bold"
-                  color="text-green-70"
-                >
-                  Healthy
-                </s-text>
-                <s-icon
-                  icon="check"
-                  color="text-green-50"
-                  class="bg-green-10 border border-green-30 rounded-full w-6 h-6 flex items-center justify-center ml-3"
-                />
-              </div>
-            </transition>
-          </div>
-        </div>
-      </perfect-scrollbar>
-
-      <div class="base-card flex items-center w-full mb-2 bg-white rounded-md">
-        <div class="px-6 my-3 py-3 border-r border-gray-20">
-          <s-icon
-            icon="cloud-f"
-            color="text-indigo-30"
-            width="24"
-            height="24"
-          />
-        </div>
-        <div class="flex items-center w-full justify-center">
-          <s-icon
-            icon="story"
-            height="18"
-            width="18"
-          />
-          <s-icon
-            icon="storyscript"
-            color="text-indigo-logo"
-            height="14"
-            width="82"
-            class="ml-2 mt-1"
-          />
-        </div>
-      </div>
-      <div class="base-card flex items-center w-full mb-2 bg-white rounded-md">
-        <div class="px-6 my-3 py-3 border-r border-gray-20">
-          <s-icon
-            icon="cloud-f"
-            color="text-indigo-30"
-            width="24"
-            height="24"
-          />
-        </div>
-        <div class="flex items-center w-full justify-center">
-          <img
-            src="/img/services/kubernetes.png"
-            srcset="/img/services/kubernetes@2x.png 2x, /img/services/kubernetes@3x.png 3x"
-            alt="kubernetes logo"
-          >
+          </transition>
         </div>
       </div>
     </perfect-scrollbar>


### PR DESCRIPTION
## Acceptance

**Given** I navigate to an example
**Then** I no longer see the kubernetes or storyscript sections of the architecture diagram

**And When** I look at an example that has many services
**Then** I see them tiling from top down (i.e if there are 3 then 1 is on the bottom row) rather than expanding horizontally when there are more than 2