### PR TITLE
style(archi): rename Architecture to Services

### DIFF
--- a/src/views/Studio/Architecture.vue
+++ b/src/views/Studio/Architecture.vue
@@ -9,7 +9,7 @@
       color="text-gray-100"
       class="bg-white pl-8 py-1 flex items-center border-t border-b border-gray-20"
     >
-      Architecture
+      Services
     </s-text>
     <perfect-scrollbar class="bg-gray-10 p-8 max-h-xs">
       <div


### PR DESCRIPTION
## Acceptance

**Given** I navigate to an example
**Then** I no longer see "Architecture" I see "Services"

