### PR TITLE
style(archi): new grid layout

### DIFF
--- a/src/assets/styles/custom/_sizes.scss
+++ b/src/assets/styles/custom/_sizes.scss
@@ -18,8 +18,8 @@
   max-width: calc(100vw - 2.5rem);
 }
 
-.w-1\/2-gutter-1 {
-  width: calc(50% - .25rem)
+.w-1\/3-gutter-1 {
+  width: calc(33% - .25rem)
 }
 
 .max-h-xs {

--- a/src/views/Studio/Architecture.vue
+++ b/src/views/Studio/Architecture.vue
@@ -11,13 +11,13 @@
     >
       Architecture
     </s-text>
-    <perfect-scrollbar class="bg-gray-10 p-8 max-h-xs">
+    <perfect-scrollbar class="bg-gray-10 p-8 max-h-xs flex flex-wrap">
       <div
         v-for="(c, idx) in services"
         :key="`card-${idx}`"
-        class="card flex items-center bg-white rounded-md w-full mb-2 transition-all-faster"
+        class="card flex items-center bg-white rounded-md w-1/3-gutter-1 mb-2 transition-all-faster"
         :class="{
-          'mr-2': idx !== services.length - 1,
+          'mr-2': (idx + 1) % 3 !== 0,
           'bg-white': showServices !== idx || !blink,
           'bg-green-20': showServices === idx && blink
         }"


### PR DESCRIPTION
## Acceptance

**Given** I navigate to an example
**Then** the Services stack in a grid instead of as a list
**And** each service is equal in size 200px wide

---

Not exactly 200px due to responsive issue (iPad), but still smaller cards