### PR TITLE
Feat/story titles

### DIFF
--- a/src/models/StorySample.ts
+++ b/src/models/StorySample.ts
@@ -27,12 +27,12 @@ export interface IStoryEvent {
 }
 
 export interface IStorySample {
+  id: string;
   name: string;
   code: string;
   collaborators: Array<IStoryCollaborator>;
   image?: string;
   events: Array<IStoryEvent>;
-  stories: Array<string>;
   services: Array<string>;
   description: string;
   tips?: Array<IStorySampleTip>;

--- a/src/samples/autolabel.ts
+++ b/src/samples/autolabel.ts
@@ -3,13 +3,13 @@ import code from './autolabel.story'
 import defaultCollaborators from './defaultCollaborators'
 
 const autolabel: IStorySample = {
-  name: 'autolabel',
+  id: 'autolabel',
+  name: 'Gmail auto-labeling',
   services: [
     'gmail',
     'machinebox',
     'redis'
   ],
-  stories: ['autolabel'],
   code,
   collaborators: defaultCollaborators,
   description:

--- a/src/samples/counter.ts
+++ b/src/samples/counter.ts
@@ -3,12 +3,12 @@ import code from './counter.story'
 import defaultCollaborators from './defaultCollaborators'
 
 const counter: IStorySample = {
-  name: 'counter',
+  id: 'counter',
+  name: 'Website hit counter',
   services: [
     'redis',
     'http'
   ],
-  stories: ['counter'],
   code,
   collaborators: defaultCollaborators,
   description:

--- a/src/samples/file.ts
+++ b/src/samples/file.ts
@@ -3,13 +3,13 @@ import code from './file.story'
 import defaultCollaborators from './defaultCollaborators'
 
 const file: IStorySample = {
+  id: 'file',
   name: 'file',
   services: [
     'http',
     'file',
     'schedule'
   ],
-  stories: ['file'],
   code,
   collaborators: defaultCollaborators,
   description: 'An ephermal file sharing app using the schedule, file and http services.',

--- a/src/samples/stripe.ts
+++ b/src/samples/stripe.ts
@@ -3,13 +3,13 @@ import code from './stripe.story'
 import defaultCollaborators from './defaultCollaborators'
 
 const stripe: IStorySample = {
-  name: 'stripe',
+  id: 'stripe',
+  name: 'Stripe plan ended',
   services: [
     'stripe',
     'postgres',
     'mailgun'
   ],
-  stories: ['stripe'],
   code,
   collaborators: defaultCollaborators,
   description:

--- a/src/samples/zoom.ts
+++ b/src/samples/zoom.ts
@@ -3,14 +3,14 @@ import code from './zoom.story'
 import defaultCollaborators from './defaultCollaborators'
 
 const zoom: IStorySample = {
-  name: 'zoom',
+  id: 'zoom',
+  name: 'Zoom audio to text transcript',
   services: [
     'zoom',
     'http',
     'deepspeech',
     'mailgun'
   ],
-  stories: ['zoom'],
   code,
   collaborators: defaultCollaborators,
   description:

--- a/src/views/Studio/Architecture.vue
+++ b/src/views/Studio/Architecture.vue
@@ -104,7 +104,7 @@ export default class Architecture extends Vue {
     return new Promise(resolve => setTimeout(resolve, time))
   }
 
-  mounted () {
+  private registerEvent () {
     event.$on('publish', async (cb: Function) => {
       this.stopPublishCb = cb
       const publish = () => {
@@ -130,6 +130,10 @@ export default class Architecture extends Vue {
         event.$emit('published', cb)
       }
     })
+  }
+
+  mounted () {
+    this.registerEvent()
   }
 
   beforeDestroy () {

--- a/src/views/Studio/Events.vue
+++ b/src/views/Studio/Events.vue
@@ -27,9 +27,7 @@
           </div>
         </div>
         <div class="flex items-center justify-start w-full p-4">
-          <div
-            class="flex items-center"
-          >
+          <div class="flex items-center">
             <s-text
               p="5"
               weight="bold"
@@ -63,7 +61,7 @@ import event from '@/event'
   }
 })
 export default class Events extends Vue {
-  @Prop({ type: Array, default: () => ([]) }) readonly events!: Array<IStoryEvent> | []
+  @Prop({ type: Array, default: () => ([]) }) readonly events!: Array<IStoryEvent>
   @Prop({ type: Number, default: 1000 }) readonly eventDelay!: number
 
   private firedEvents: any[] = []

--- a/src/views/Studio/index.vue
+++ b/src/views/Studio/index.vue
@@ -23,7 +23,7 @@
             weight="semibold"
             color="text-gray-100"
           >
-            {{ payload.stories[0] }}.story
+            {{ payload.name }}
           </s-text>
           <s-text
             p="6"
@@ -67,9 +67,7 @@
         class="w-full flex"
         :class="{'h-0': fullscreen}"
       >
-        <s-architecture
-          :services="payload.services"
-        />
+        <s-architecture :services="payload.services" />
       </div>
     </div>
     <s-tabs

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -31,13 +31,11 @@
       <div class="flex flex-col md:flex-row md:flex-wrap justify-center mb-12">
         <div
           v-for="(card, idx) in samples"
-          :id="`sample-card-${card.name}`"
+          :id="`sample-card-${card.id}`"
           :key="`sample-card-${idx}`"
           class="bg-white rounded-xl m-4 w-full md:w-1/2 lg:w-1/3 sample-card shadow-card flex flex-col"
         >
-          <div
-            class="flex flex-col mt-8 px-8 pb-6 border-b border-solid border-gray-10"
-          >
+          <div class="flex flex-col mt-8 px-8 pb-6 border-b border-solid border-gray-10">
             <div class="flex items-start">
               <div class="w-1/5 mr-6">
                 <img
@@ -53,7 +51,7 @@
                   color="text-gray-100"
                   class="title"
                 >
-                  {{ card.name }}.story
+                  {{ card.name }}
                 </s-text>
                 <s-text
                   p="3"
@@ -92,12 +90,12 @@
               </div>
             </div>
             <s-button
-              :id="`explore-${card.name}`"
+              :id="`explore-${card.id}`"
               icon="rocket-o"
               primary
               reverse
               danger
-              @click="go(card.name)"
+              @click="go(card.id)"
             >
               Explore
             </s-button>
@@ -109,9 +107,7 @@
         />
       </div>
 
-      <s-footer
-        @scrollTop="$refs.content.$el.scrollTop = 0"
-      />
+      <s-footer @scrollTop="$refs.content.$el.scrollTop = 0" />
     </perfect-scrollbar>
   </div>
 </template>

--- a/tests/e2e/welcome.e2e.ts
+++ b/tests/e2e/welcome.e2e.ts
@@ -42,19 +42,19 @@ describe('Welcome', () => {
       const base: IStorySample = sample as IStorySample
 
       it(`should display the ${base.name} example content in a card`, async () => {
-        const title = await page.$eval(`#sample-card-${base.name} .title`, (e: Element) => e.innerHTML.trim())
-        const description = await page.$eval(`#sample-card-${base.name} .description`, (e: Element) => e.innerHTML.trim())
+        const title = await page.$eval(`#sample-card-${base.id} .title`, (e: Element) => e.innerHTML.trim())
+        const description = await page.$eval(`#sample-card-${base.id} .description`, (e: Element) => e.innerHTML.trim())
 
         expect.assertions(2)
-        expect(title).toEqual(`${base.name}.story`)
+        expect(title).toEqual(`${base.name}`)
         expect(description).toEqual(base.description)
       })
 
       it(`should redirect to the ${base.name} story`, async () => {
         expect.assertions(1)
-        await page.click(`#explore-${base.name}`)
+        await page.click(`#explore-${base.id}`)
         await page.waitForSelector('#studio')
-        expect(page.url()).toEqual(`${TEST_URL}/example/${base.name}`)
+        expect(page.url()).toEqual(`${TEST_URL}/example/${base.id}`)
       })
     }
   })

--- a/tests/unit/samples/index.spec.ts
+++ b/tests/unit/samples/index.spec.ts
@@ -8,8 +8,8 @@ describe('Counter sample', () => {
     for (const s in samples) {
       const e: IStorySample = samples[s]
       expect(e).toBeDefined()
+      expect(e.id).toBeDefined()
       expect(e.name).toBeDefined()
-      expect(e.stories).toBeDefined()
       expect(e.services).toBeDefined()
       expect(e.code).toBeDefined()
       expect(e.description).toBeDefined()

--- a/tests/unit/views/Studio/Architecture.spec.ts
+++ b/tests/unit/views/Studio/Architecture.spec.ts
@@ -5,7 +5,7 @@ import event from '@/event'
 describe('Plaground::Architecture', () => {
   let archi: Wrapper<Architecture>
   let vm: any
-  const fakeCB = jest.fn()
+  let fakeCB = jest.fn()
 
   afterEach(() => {
     archi.destroy()
@@ -26,6 +26,24 @@ describe('Plaground::Architecture', () => {
     event.$emit('publish', fakeCB)
     expect(archi.html()).toBeDefined()
     expect(vm).toHaveProperty('services', ['toto'])
+  })
+
+  it('should display services but not emit', async () => {
+    expect.assertions(1)
+    archi = shallowMount(Architecture, {
+      propsData: {
+        services: ['toto'],
+        startAfter: 0,
+        serviceDelay: -1
+      }
+    })
+    vm = archi.vm as any
+    vm.sleep = jest.fn()
+    fakeCB = jest.fn()
+
+    vm.destroyed = true
+    event.$emit('publish', fakeCB)
+    expect(fakeCB).not.toHaveBeenCalled()
   })
 
   describe('.sleep()', () => {

--- a/tests/unit/views/Studio/Events.spec.ts
+++ b/tests/unit/views/Studio/Events.spec.ts
@@ -52,6 +52,17 @@ describe('Events.vue', () => {
     expect(events.html()).toBeTruthy()
   })
 
+  it('should mount without events', () => {
+    expect.assertions(1)
+    const view = shallowMount(Events, {
+      propsData: {
+        eventDelay: 0
+      }
+    })
+    expect(view.html()).toBeTruthy()
+    view.destroy()
+  })
+
   describe('.triggerEvent(fn, idx)', () => {
     it('should add event to the event array', () => {
       expect.assertions(1)


### PR DESCRIPTION
- [x] update IStorySample
  - [x] change name to id
  - [x] remove stories array (since we don't use files anymore)
- [x] update welcome view with name and links to the id prop
- [x] update editor view with story name instead of file name
 
- [x] fix unit tests
- [x] e2e tests

___

### Acceptance
**When** I navigate to the studio
**Then** I see the title of the story in the example card instead of "counter.story", for example. See list of titles below.

**When** I navigate to an example
**Then** I see the story title in the top left corner

counter.story: "Website hit counter"
autolablel.story: "Gmail auto-labeling"
stripe.story: "Stripe plan ended"
zoom.story: "Zoom audio to text transcript"