### PR TITLE
fix(routing): fix issue when redirecting to /welcome

### DIFF
--- a/src/views/index.vue
+++ b/src/views/index.vue
@@ -9,13 +9,22 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Vue, Watch } from 'vue-property-decorator'
 
 @Component({
   name: 'StudioIndex'
 })
 export default class StudioIndex extends Vue {
   mounted () {
+    this.checkRoute()
+  }
+
+  @Watch('$route')
+  private onRouteChange () {
+    this.checkRoute()
+  }
+
+  private checkRoute () {
     if ((!this.$route || !this.$route.params || !('sample' in this.$route.params)) &&
       (this.$route && this.$route.path && !this.$route.path.includes('welcome'))) {
       this.$router.push({ name: 'welcome' })

--- a/tests/unit/views/index.spec.ts
+++ b/tests/unit/views/index.spec.ts
@@ -29,16 +29,16 @@ describe('index.vue', () => {
       expect(view.html()).toBeDefined()
     })
 
-    it('should redirect', async () => {
+    it('should redirect', () => {
       expect.assertions(1)
       expect(push).toHaveBeenCalled()
     })
 
-    it('isIntro should be false', async () => {
+    it('isIntro should be false', () => {
       expect.assertions(1)
       const rpush = jest.fn()
 
-      const idxView = await shallowMount(Index, {
+      const idxView = shallowMount(Index, {
         stubs: {
           RouterView: true
         },
@@ -53,6 +53,15 @@ describe('index.vue', () => {
       })
       expect(rpush).not.toHaveBeenCalled()
       idxView.destroy()
+    })
+
+    describe('watcher', () => {
+      it('should call the checkRoute method when route changes', () => {
+        const vm = view.vm as any
+        vm.checkRoute = jest.fn()
+        vm.onRouteChange()
+        expect(vm.checkRoute).toHaveBeenCalled()
+      })
     })
   })
 })


### PR DESCRIPTION
- [x] Add missing unit test coverage

## Acceptance

**When** I navigate to https://studio.storyscript.io/
**And** I click Explore on any of the examples
**And** I click the back button
**And** I click the back button again
**Then** I should be shown the example I was previously at correctly

---

>**Then** I should be shown the example I was previously at correctly

I was not able to do that, instead I rechecked the route, so the user at least stays on `/welcome`