### PR TITLE
chore(InfosPane): make infospane fixed.

### DIFF
--- a/src/app/views/Editor/InfosPane.vue
+++ b/src/app/views/Editor/InfosPane.vue
@@ -4,7 +4,7 @@
       p="4"
       weight="medium"
       align="center"
-      class="text-gray-50 mt-3"
+      class="text-gray-50 mt-3 sticky top-3"
     >
       0 Suggestions, 0 Error
     </s-text>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -151,6 +151,7 @@ module.exports = {
       inset: {
         min: '.125rem',
         1: '.25rem',
+        3: '.75rem',
         half: '50%',
         full: '100%'
       },


### PR DESCRIPTION
Make the suggestions/errors text fixed in the infos pane.


I am not sure about how this should be done correctly but this way did work for my screen. Not sure if this is the correct thing to do which would work on all screens.
context: `inherit` uses px values and not computed values??

story: https://www.pivotaltracker.com/story/show/170277014